### PR TITLE
fix: resolve JSX SyntaxError in AtomixGlass stories

### DIFF
--- a/src/components/AtomixGlass/stories/Examples.stories.tsx
+++ b/src/components/AtomixGlass/stories/Examples.stories.tsx
@@ -883,6 +883,7 @@ export const NotificationCenter: Story = {
             </div>
           </AtomixGlass>
         </div>
+        </div>
       </BackgroundWrapper>
     );
   },
@@ -1161,6 +1162,7 @@ export const LoginForm: Story = {
               </div>
             </div>
           </AtomixGlass>
+        </div>
         </div>
       </BackgroundWrapper>
     );


### PR DESCRIPTION
🎯 **What:** Fixed a JSX SyntaxError in `src/components/AtomixGlass/stories/Examples.stories.tsx`.
📊 **Coverage:** Resolved a missing closing `div` tag that caused Storybook build/indexing failures.
✨ **Result:** Improved Storybook stability and fixed a blocking build error that was affecting CI performance checks.

---
*PR created automatically by Jules for task [2041632033094838340](https://jules.google.com/task/2041632033094838340) started by @liimonx*