### PR TITLE
Fix ESM module resolution for ThemeValidator in CLI

### DIFF
--- a/scripts/cli/theme-bridge.js
+++ b/scripts/cli/theme-bridge.js
@@ -29,12 +29,13 @@ export async function executeThemeCommand(command, args = [], options = {}) {
     // Path to the theme CLI
     const themeCliPath = join(__dirname, '../../src/lib/theme/devtools/CLI.ts');
 
-    // Use ts-node to execute TypeScript CLI
-    const tsNodePath = join(__dirname, '../../node_modules/.bin/ts-node');
+    // Use node with ts-node loader to execute TypeScript CLI
+    // This approach is more robust for ESM environments than invoking ts-node binary directly
 
     return new Promise((resolve, reject) => {
-      const child = spawn(tsNodePath, [
-        '--esm',
+      const child = spawn(process.execPath, [
+        '--loader',
+        'ts-node/esm',
         '--experimental-specifier-resolution=node',
         themeCliPath,
         command,

--- a/src/lib/theme/devtools/CLI.ts
+++ b/src/lib/theme/devtools/CLI.ts
@@ -11,16 +11,8 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
-// import { ThemeValidator } from './ThemeValidator.js';
+import { ThemeValidator } from './ThemeValidator.js';
 import boxen from 'boxen';
-
-// Stub validator for now to avoid ESM resolution issues in CLI
-// TODO: Fix ESM module resolution for ThemeValidator in CLI context
-class ThemeValidator {
-    validate() {
-        return { valid: true, errors: [], warnings: [], a11yIssues: [] };
-    }
-}
 
 const program = new Command();
 

--- a/src/lib/theme/devtools/__tests__/ThemeValidator.test.ts
+++ b/src/lib/theme/devtools/__tests__/ThemeValidator.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { ThemeValidator } from '../ThemeValidator';
+import { createTestThemeObject } from '../../test/testTheme';
+import { Theme } from '../../types';
+
+describe('ThemeValidator', () => {
+    const validator = new ThemeValidator();
+
+    it('should validate a valid theme', () => {
+        const theme = createTestThemeObject();
+        const result = validator.validate(theme);
+
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    it('should report errors for invalid theme', () => {
+        const theme = createTestThemeObject();
+        // @ts-ignore
+        theme.palette.primary.main = 'invalid-color';
+
+        const result = validator.validate(theme);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+        const invalidColorError = result.errors.find(e => e.includes('Invalid color value'));
+        expect(invalidColorError).toBeDefined();
+    });
+
+    it('should report warnings for accessibility issues', () => {
+        const theme = createTestThemeObject();
+        // Create a low contrast situation
+        theme.palette.primary.main = '#ffffff';
+        theme.palette.primary.contrastText = '#ffffff';
+
+        const result = validator.validate(theme);
+
+        // It might be valid but have warnings or a11y issues
+        expect(result.a11yIssues.length).toBeGreaterThan(0);
+        const contrastIssue = result.a11yIssues.find(i => i.type === 'contrast');
+        expect(contrastIssue).toBeDefined();
+    });
+});


### PR DESCRIPTION
Resolved a TODO item in `src/lib/theme/devtools/CLI.ts` by enabling the actual `ThemeValidator` class and removing the stub. 

Updated `scripts/cli/theme-bridge.js` to correctly invoke the CLI using `node` with `ts-node/esm` loader and `--experimental-specifier-resolution=node` flag. This fixes the ESM module resolution issue (`ERR_MODULE_NOT_FOUND`) that prevented the CLI from running correctly with `ts-node`.

Also added a new test file `src/lib/theme/devtools/__tests__/ThemeValidator.test.ts` to ensure the validator logic works as expected.

---
*PR created automatically by Jules for task [5920986279119861941](https://jules.google.com/task/5920986279119861941) started by @liimonx*