### PR TITLE
fix(types): resolve missing type declarations for theme-tools and build-tools

### DIFF
--- a/build-tools/index.d.ts
+++ b/build-tools/index.d.ts
@@ -1,0 +1,44 @@
+import {
+  AtomixVitePluginOptions,
+  AtomixRollupPluginOptions,
+  AtomixLoaderOptions,
+  AtomixBuildToolOptions,
+  BuildTool
+} from './types';
+
+export * from './types';
+
+/**
+ * Atomix Vite Plugin
+ */
+export function vitePlugin(options?: AtomixVitePluginOptions): any;
+
+/**
+ * Atomix Webpack Loader
+ */
+export function webpackLoader(source: string): string;
+
+/**
+ * Atomix Rollup Plugin
+ */
+export function rollupPlugin(options?: AtomixRollupPluginOptions): any;
+
+/**
+ * Gets the appropriate plugin/loader based on the detected build tool
+ */
+export function getIntegration(buildTool: BuildTool, options?: AtomixBuildToolOptions): any;
+
+/**
+ * Detects the build tool used in the current project
+ */
+export function detectBuildTool(): BuildTool;
+
+/**
+ * Initialize the appropriate integration based on detected build tool
+ */
+export function initAutoIntegration(options?: AtomixBuildToolOptions): any;
+
+/**
+ * Get available themes
+ */
+export function getAvailableThemes(atomixRoot?: string): string[];

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -3,7 +3,15 @@
   "version": "1.0.0",
   "description": "Build tool integrations for the Atomix design system",
   "main": "index.js",
+  "types": "index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/index-dts.ts
+++ b/src/index-dts.ts
@@ -4,6 +4,9 @@ export * from './components';
 // Export lib utilities
 export * from './lib';
 
+// Export theme tools for developer-friendly usage
+export * from './lib/theme-tools';
+
 // Export layouts
 export * from './layouts';
 


### PR DESCRIPTION
This PR addresses issues reported by `attw` where type declarations were missing for certain exports.

Changes include:
1.  **`src/index-dts.ts`**: Added `export * from './lib/theme-tools';` to ensure the main type definition file includes theme tools, mirroring the runtime exports.
2.  **`build-tools/index.d.ts`**: Created a new type definition file for the build tools entry point.
3.  **`package.json`**: Updated the `./build-tools` export to explicitly point to the new type definition file.
4.  **`build-tools/package.json`**: Added `types` and `exports` fields to support correct resolution in nested package scenarios.

These changes ensure that TypeScript consumers can correctly import and use `theme-tools` and `build-tools` without type errors. Verified with `npm run attw`.

---
*PR created automatically by Jules for task [16970306664873599104](https://jules.google.com/task/16970306664873599104) started by @liimonx*