### PR TITLE
Update Hero component to support Compound Component Pattern

### DIFF
--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -279,6 +279,43 @@ export const BasicUsage: Story = {
   },
 };
 
+/**
+ * Hero using Compound Component Pattern
+ */
+export const CompoundUsage: Story = {
+  render: (args) => (
+    <Hero {...args}>
+      <Hero.Content>
+        <Hero.Title level="h1">Compound Component Pattern</Hero.Title>
+        <Hero.Subtitle>Fully Customizable Structure</Hero.Subtitle>
+        <Hero.Text>
+          This example demonstrates the new Compound Component pattern, allowing full control over the internal structure of the Hero component.
+        </Hero.Text>
+        <Hero.Actions>
+          <Button variant="primary" className="u-mr-3">
+            Get Started
+          </Button>
+          <Button variant="outline">Learn More</Button>
+        </Hero.Actions>
+      </Hero.Content>
+    </Hero>
+  ),
+  args: {
+    fullViewportHeight: true,
+    alignment: 'center',
+    backgroundImageSrc: 'https://picsum.photos/id/1015/1920/1080',
+    title: '', // Ignored but kept for types
+    showOverlay: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Using the Compound Component pattern for maximum flexibility.',
+      },
+    },
+  },
+};
+
 export const WithImage: Story = {
   args: {
     title: 'Beautiful Interfaces',

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Hero from './Hero';
+
+// Mock AtomixGlass component
+vi.mock('../AtomixGlass/AtomixGlass', () => ({
+  AtomixGlass: ({ children, className }: any) => (
+    <div data-testid="atomix-glass" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+describe('Hero Component', () => {
+  describe('Monolithic Usage', () => {
+    it('renders title and subtitle correctly', () => {
+      render(<Hero title="Test Title" subtitle="Test Subtitle" />);
+
+      expect(screen.getByText('Test Title')).toBeInTheDocument();
+      expect(screen.getByText('Test Subtitle')).toBeInTheDocument();
+    });
+
+    it('renders text content correctly', () => {
+      render(<Hero title="Title" text="Test Description" />);
+
+      expect(screen.getByText('Test Description')).toBeInTheDocument();
+    });
+
+    it('renders background image correctly', () => {
+      const bgSrc = 'test-bg.jpg';
+      render(<Hero title="Title" backgroundImageSrc={bgSrc} />);
+
+      const bgImage = screen.getByAltText('Background');
+      expect(bgImage).toBeInTheDocument();
+      expect(bgImage).toHaveAttribute('src', bgSrc);
+    });
+
+    it('renders foreground image correctly', () => {
+      const imgSrc = 'test-img.jpg';
+      render(<Hero title="Title" imageSrc={imgSrc} imageAlt="Foreground Image" />);
+
+      const image = screen.getByAltText('Foreground Image');
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute('src', imgSrc);
+    });
+
+    it('renders actions correctly', () => {
+      render(
+        <Hero
+          title="Title"
+          actions={<button>Click Me</button>}
+        />
+      );
+
+      expect(screen.getByText('Click Me')).toBeInTheDocument();
+    });
+
+    it('renders children correctly', () => {
+      render(
+        <Hero title="Title">
+          <div data-testid="child-content">Child Content</div>
+        </Hero>
+      );
+
+      expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Compound Component Usage', () => {
+    it('renders Hero.Title, Hero.Subtitle, Hero.Text correctly', () => {
+      render(
+        <Hero title="">
+          <Hero.Content>
+            <Hero.Title>Compound Title</Hero.Title>
+            <Hero.Subtitle>Compound Subtitle</Hero.Subtitle>
+            <Hero.Text>Compound Text</Hero.Text>
+          </Hero.Content>
+        </Hero>
+      );
+
+      expect(screen.getByText('Compound Title')).toBeInTheDocument();
+      expect(screen.getByText('Compound Title').tagName).toBe('H1');
+      expect(screen.getByText('Compound Subtitle')).toBeInTheDocument();
+      expect(screen.getByText('Compound Text')).toBeInTheDocument();
+    });
+
+    it('renders Hero.Actions correctly', () => {
+      render(
+        <Hero title="">
+          <Hero.Content>
+            <Hero.Actions>
+              <button>Action</button>
+            </Hero.Actions>
+          </Hero.Content>
+        </Hero>
+      );
+
+      expect(screen.getByText('Action')).toBeInTheDocument();
+    });
+
+    it('renders Hero.Image correctly', () => {
+      render(
+        <Hero title="">
+          <Hero.Image src="compound-img.jpg" alt="Compound Image" />
+        </Hero>
+      );
+
+      const img = screen.getByAltText('Compound Image');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', 'compound-img.jpg');
+    });
+
+    it('renders Hero.Background via backgroundElement prop', () => {
+      render(
+        <Hero
+          title="Title"
+          backgroundElement={<Hero.Background src="bg.jpg" data-testid="custom-bg" />}
+        />
+      );
+
+      const bg = screen.getByTestId('custom-bg');
+      expect(bg).toBeInTheDocument();
+      // Verify it renders the image inside
+      const img = screen.getByAltText('Background');
+      expect(img).toHaveAttribute('src', 'bg.jpg');
+    });
+
+    it('Hero.Content supports glass prop', () => {
+      render(
+        <Hero title="">
+          <Hero.Content glass>
+             Glass Content
+          </Hero.Content>
+        </Hero>
+      );
+
+      expect(screen.getByTestId('atomix-glass')).toBeInTheDocument();
+      expect(screen.getByText('Glass Content')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,10 +1,139 @@
-import React, { CSSProperties, useEffect } from 'react';
-import { HeroProps, HeroAlignment } from '../../lib/types/components';
+import React, { CSSProperties, useEffect, ReactNode } from 'react';
+import { HeroProps, HeroAlignment, AtomixGlassProps } from '../../lib/types/components';
 import { useHero } from '../../lib/composables/useHero';
 import { HERO } from '../../lib/constants/components';
 import { AtomixGlass } from '../AtomixGlass/AtomixGlass';
 
-export const Hero: React.FC<HeroProps> = ({
+// Subcomponents
+export interface HeroTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div';
+}
+
+const HeroTitle = ({ children, className, level = 'h1', ...props }: HeroTitleProps) => {
+  const Tag = level as any;
+  return (
+    <Tag className={`${HERO.SELECTORS.TITLE.replace('.', '')} ${className || ''}`.trim()} {...props}>
+      {children}
+    </Tag>
+  );
+};
+
+const HeroSubtitle = ({ children, className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => {
+  return (
+    <p className={`${HERO.SELECTORS.SUBTITLE.replace('.', '')} ${className || ''}`.trim()} {...props}>
+      {children}
+    </p>
+  );
+};
+
+const HeroText = ({ children, className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => {
+  return (
+    <p className={`${HERO.SELECTORS.TEXT.replace('.', '')} ${className || ''}`.trim()} {...props}>
+      {children}
+    </p>
+  );
+};
+
+const HeroActions = ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div className={`${HERO.SELECTORS.ACTIONS.replace('.', '')} ${className || ''}`.trim()} {...props}>
+      {children}
+    </div>
+  );
+};
+
+export interface HeroContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  glass?: AtomixGlassProps | boolean;
+}
+
+const HeroContent = ({ children, className, style, glass, ...props }: HeroContentProps) => {
+  const contentClass = `${HERO.SELECTORS.CONTENT.replace('.', '')} ${className || ''}`.trim();
+
+  if (glass) {
+    const glassProps = typeof glass === 'boolean' ? {
+      displacementScale: 60,
+      blurAmount: 3,
+      saturation: 180,
+      aberrationIntensity: 0,
+      cornerRadius: 8,
+      overLight: false,
+      mode: 'standard' as const,
+    } : glass;
+
+    return (
+      <div className={contentClass} style={style} {...props}>
+        <AtomixGlass {...glassProps}>
+          <div className="u-p-4">
+            {children}
+          </div>
+        </AtomixGlass>
+      </div>
+    );
+  }
+
+  return (
+    <div className={contentClass} style={style} {...props}>
+      {children}
+    </div>
+  );
+};
+
+export interface HeroImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  wrapperClassName?: string;
+  wrapperStyle?: React.CSSProperties;
+}
+
+const HeroImage = ({
+  src,
+  alt = '',
+  className,
+  wrapperClassName,
+  wrapperStyle,
+  ...props
+}: HeroImageProps) => {
+  return (
+    <div
+      className={`${HERO.SELECTORS.IMAGE_WRAPPER.replace('.', '')} ${wrapperClassName || ''}`.trim()}
+      style={wrapperStyle}
+    >
+      <img
+        src={src}
+        alt={alt}
+        className={`${HERO.SELECTORS.IMAGE.replace('.', '')} ${className || ''}`.trim()}
+        {...props}
+      />
+    </div>
+  );
+};
+
+const HeroBackground = ({ className, style, src, children, ...props }: React.HTMLAttributes<HTMLDivElement> & { src?: string }) => {
+  return (
+    <div
+      className={`${HERO.SELECTORS.BG.replace('.', '')} ${className || ''}`.trim()}
+      style={style}
+      {...props}
+    >
+      {src && (
+         <img
+            src={src}
+            alt="Background"
+            className={HERO.SELECTORS.BG_IMAGE.replace('.', '')}
+          />
+      )}
+      {children}
+    </div>
+  );
+};
+
+export const Hero: React.FC<HeroProps> & {
+  Title: typeof HeroTitle;
+  Subtitle: typeof HeroSubtitle;
+  Text: typeof HeroText;
+  Actions: typeof HeroActions;
+  Content: typeof HeroContent;
+  Image: typeof HeroImage;
+  Background: typeof HeroBackground;
+} = ({
   title,
   subtitle,
   text,
@@ -38,6 +167,7 @@ export const Hero: React.FC<HeroProps> = ({
   headingLevel = 'h1',
   reverseOnMobile = false,
   parts,
+  backgroundElement,
   ...rest
 }: HeroProps) => {
   // Define dynamic heading tag
@@ -421,6 +551,7 @@ export const Hero: React.FC<HeroProps> = ({
       data-parallax-intensity={parallax ? parallaxIntensity : undefined}
       {...rest}
     >
+      {backgroundElement}
       {renderBackground()}
       <div
         className={`${HERO.SELECTORS.CONTAINER.replace('.', '')} o-container ${parts?.container?.className || ''}`.trim()}
@@ -450,6 +581,14 @@ export const Hero: React.FC<HeroProps> = ({
     </div>
   );
 };
+
+Hero.Title = HeroTitle;
+Hero.Subtitle = HeroSubtitle;
+Hero.Text = HeroText;
+Hero.Actions = HeroActions;
+Hero.Content = HeroContent;
+Hero.Image = HeroImage;
+Hero.Background = HeroBackground;
 
 export type { HeroProps };
 

--- a/src/lib/types/components.ts
+++ b/src/lib/types/components.ts
@@ -1140,6 +1140,12 @@ export interface HeroProps
    * Granular part-based styling
    */
   parts?: HeroParts;
+
+  /**
+   * Custom background element to render behind the content
+   * @example <Hero.Background src="..." />
+   */
+  backgroundElement?: ReactNode;
 }
 
 /**


### PR DESCRIPTION
- Refactored `Hero` component to export and attach subcomponents: `Hero.Title`, `Hero.Subtitle`, `Hero.Text`, `Hero.Actions`, `Hero.Content`, `Hero.Image`, `Hero.Background`.
- Implemented logic to render `children` inside the grid layout when present, enabling the Compound Component Pattern.
- Added `CompoundUsage` story to `Hero.stories.tsx` to demonstrate the new pattern.
- Added comprehensive unit tests in `Hero.test.tsx` covering all subcomponents.
- Updated `HeroProps` interface to include `backgroundElement`.
- Verified changes with unit tests and visual verification via Playwright script.

---
*PR created automatically by Jules for task [2055150232569452441](https://jules.google.com/task/2055150232569452441) started by @liimonx*