### PR TITLE
Make CSS utility classes robust

### DIFF
--- a/src/styles/02-tools/_tools.breakpoints.scss
+++ b/src/styles/02-tools/_tools.breakpoints.scss
@@ -8,7 +8,7 @@
 // Breakpoint viewport sizes and media queries.
 @mixin media-breakpoint-up($name, $breakpoints: breakpoints.$grid-breakpoints) {
   $min: map.get($breakpoints, $name);
-  @if $min {
+  @if $min and $min != 0 {
     @media (min-width: $min) {
       @content;
     }

--- a/src/styles/02-tools/_tools.utility-api.scss
+++ b/src/styles/02-tools/_tools.utility-api.scss
@@ -22,7 +22,7 @@ $utility-defaults: (
   class: null,
   state: null,
   local-vars: (),
-  rtl: true,
+  is-important: true,
 ) !default;
 
 // Core function to generate utility classes
@@ -77,11 +77,11 @@ $utility-defaults: (
           --atomix-u-#{$css-variable-name}: #{$value};
         } @else if $properties {
           @each $property in $properties {
-            #{$property}: $value if(map.get($utility, rtl), null, !important);
+            #{$property}: $value if(map.get($utility, is-important), !important, null);
           }
         } @else if $value != null {
           // Guard: only emit property declaration if value is not null
-          #{$property-class}: $value if(map.get($utility, rtl), null, !important);
+          #{$property-class}: $value if(map.get($utility, is-important), !important, null);
         }
 
         // Add local CSS variables if specified
@@ -111,11 +111,11 @@ $utility-defaults: (
           --atomix-u-#{$css-variable-name}#{$modifier}: #{$value};
         } @else if $properties {
           @each $property in $properties {
-            #{$property}: $value if(map.get($utility, rtl), null, !important);
+            #{$property}: $value if(map.get($utility, is-important), !important, null);
           }
         } @else if $value != null {
           // Guard: only emit property declaration if value is not null
-          #{$base-class}: $value if(map.get($utility, rtl), null, !important);
+          #{$base-class}: $value if(map.get($utility, is-important), !important, null);
         }
 
         // Add local CSS variables if specified
@@ -169,7 +169,7 @@ $utility-defaults: (
         values: map.get($config, values),
         class: map.get($config, class),
         state: map.get($config, state),
-        rtl: map.get($config, rtl),
+        is-important: map.get($config, is-important),
         css-var: map.get($config, css-var),
         local-vars: map.get($config, local-vars),
         responsive: map.get($config, responsive),

--- a/src/styles/99-utilities/_utilities.text.scss
+++ b/src/styles/99-utilities/_utilities.text.scss
@@ -99,7 +99,6 @@ $utilities-text: (
     values: (
       break: break-word,
     ),
-    rtl: false,
   ),
   'color': (
     property: color,


### PR DESCRIPTION
This change audits and improves the robustness of the CSS utility classes. 

Key improvements:
1.  **Enforced `!important`**: Utility classes are now generated with `!important` by default. This prevents them from being overridden by component styles with higher specificity, making them more reliable and predictable (robust). The configuration option controlling this behavior was renamed from the confusing `rtl` to `is-important`.
2.  **Cleaned up Media Queries**: The `media-breakpoint-up` mixin was fixed to avoid wrapping base styles in redundant `@media (min-width: 0)` blocks, reducing CSS size and complexity.

These changes ensure that utility classes behave as expected (overrides) and generate cleaner CSS output.

---
*PR created automatically by Jules for task [15585278476166888402](https://jules.google.com/task/15585278476166888402) started by @liimonx*