### PR TITLE
🧹 remove commented-out exports in composables index

### DIFF
--- a/src/lib/composables/index.ts
+++ b/src/lib/composables/index.ts
@@ -1,6 +1,3 @@
-// Button composables
-// export * from './useButton';
-
 // Accordion composables
 export * from './useAccordion';
 
@@ -29,7 +26,6 @@ export * from './useEdgePanel';
 export * from './useTodo';
 
 // Form composables
-// export * from './useCheckbox';
 export * from './useForm';
 export * from './useFormGroup';
 


### PR DESCRIPTION
This PR removes commented-out export statements in `src/lib/composables/index.ts`.

🎯 **What:** Removed `// export * from './useButton';` and `// export * from './useCheckbox';`.
💡 **Why:** Commented-out dead code reduces readability and maintainability. The referenced files do not exist in the codebase.
✅ **Verification:** Manually verified the file content and confirmed the absence of the referenced source files. Code review confirmed the change is safe and follows repository standards.
✨ **Result:** A cleaner aggregator file for composables.

---
*PR created automatically by Jules for task [11082265591140098120](https://jules.google.com/task/11082265591140098120) started by @liimonx*