### PR TITLE
Fix ESM module resolution for ThemeValidator in CLI

### DIFF
--- a/src/lib/theme/devtools/CLI.ts
+++ b/src/lib/theme/devtools/CLI.ts
@@ -11,7 +11,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ThemeValidator } from './ThemeValidator';
+import { ThemeValidator } from './ThemeValidator.js';
 import boxen from 'boxen';
 
 const program = new Command();


### PR DESCRIPTION
Fixes ESM module resolution issue for ThemeValidator in the CLI context by adding the `.js` extension to the import. This ensures that the CLI can correctly resolve the ThemeValidator module when running in an ESM environment (e.g., via tsx or Node). Also verified that the stub mentioned in the issue description was not present in the actual file, so no stub removal was necessary beyond ensuring the import is active. Verified CLI functionality by running the help command.

---
*PR created automatically by Jules for task [17900381041121412507](https://jules.google.com/task/17900381041121412507) started by @liimonx*