### PR TITLE
⚡ Optimize Hero Slider Autoplay Interval

### DIFF
--- a/src/lib/composables/__tests__/useHeroBackgroundSlider.test.tsx
+++ b/src/lib/composables/__tests__/useHeroBackgroundSlider.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react';
+import { useHeroBackgroundSlider } from '../useHeroBackgroundSlider';
+import { HeroBackgroundSliderConfig } from '../../types/components';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+describe('useHeroBackgroundSlider Performance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('should not reset interval frequently during autoplay', () => {
+    const config: HeroBackgroundSliderConfig = {
+      slides: [
+        { type: 'image', src: 'slide1.jpg' },
+        { type: 'image', src: 'slide2.jpg' },
+        { type: 'image', src: 'slide3.jpg' },
+      ],
+      autoplay: {
+        delay: 3000,
+      },
+      transitionDuration: 1000,
+    };
+
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+    const { result } = renderHook(() => useHeroBackgroundSlider(config));
+
+    // Reset call count after initial render
+    clearIntervalSpy.mockClear();
+
+    // 1st Transition
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // 2nd Transition
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    console.log(`clearInterval calls: ${clearIntervalSpy.mock.calls.length}`);
+
+    // With optimization, the interval should persist and not be cleared during transitions
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
💡 **What:**
I refactored the `useHeroBackgroundSlider` hook to use a `ref`-based callback for the autoplay interval. This allows the interval to persist across state changes (like `isTransitioning` and `currentIndex` updates) instead of being cleared and recreated.

🎯 **Why:**
The previous implementation included `nextSlide` and `isTransitioning` in the `useEffect` dependencies for the autoplay interval. Since these values change on every slide transition, the interval was constantly being cleared and restarted, leading to unnecessary churn and potentially inconsistent timing (e.g., if a user interaction triggered a state update).

📊 **Measured Improvement:**
I created a test case (`src/lib/composables/__tests__/useHeroBackgroundSlider.test.tsx`) that spies on `clearInterval`.
- **Baseline:** The interval was cleared **4 times** during 2 slide transitions.
- **Optimized:** The interval is cleared **0 times** during the same period (it persists until the component unmounts or autoplay config changes).

This change ensures the slider respects the configured `delay` more accurately and reduces the overhead of timer management.

---
*PR created automatically by Jules for task [11951237884125871984](https://jules.google.com/task/11951237884125871984) started by @liimonx*