### PR TITLE
⚡ Memoize renderContent in TreemapChart

### DIFF
--- a/src/components/Chart/TreemapChart.tsx
+++ b/src/components/Chart/TreemapChart.tsx
@@ -98,21 +98,25 @@ interface TreemapChartProps extends Omit<ChartProps, 'type' | 'datasets'> {
   };
 }
 
+const DEFAULT_COLOR_CONFIG: NonNullable<TreemapChartProps['colorConfig']> = { scheme: 'category' };
+const DEFAULT_LABEL_CONFIG = {
+  showLabels: true,
+  minSize: 1000,
+  fontSize: 12,
+  textColor: 'white',
+};
+const DEFAULT_CONFIG = {};
+
 const TreemapChart = memo(
   forwardRef<HTMLDivElement, TreemapChartProps>(
     (
       {
         data = [],
         algorithm = 'squarified',
-        colorConfig = { scheme: 'category' },
-        labelConfig = {
-          showLabels: true,
-          minSize: 1000,
-          fontSize: 12,
-          textColor: 'white',
-        },
+        colorConfig = DEFAULT_COLOR_CONFIG,
+        labelConfig = DEFAULT_LABEL_CONFIG,
         onDataPointClick,
-        config = {},
+        config = DEFAULT_CONFIG,
         ...props
       },
       ref
@@ -357,16 +361,17 @@ const TreemapChart = memo(
         []
       );
 
-      const renderContent = ({
-        scales,
-        colors,
-        datasets: renderedDatasets,
-        handlers,
-        hoveredPoint,
-      }: ChartRenderContentParams) => {
-        if (!data.length) return null;
+      const renderContent = useCallback(
+        ({
+          scales,
+          colors,
+          datasets: renderedDatasets,
+          handlers,
+          hoveredPoint,
+        }: ChartRenderContentParams) => {
+          if (!data.length) return null;
 
-        // Calculate available space with padding
+          // Calculate available space with padding
         const padding = 20;
         const availableWidth = scales.width - padding * 2;
         const availableHeight = scales.height - padding * 2;
@@ -467,17 +472,22 @@ const TreemapChart = memo(
                 </g>
               );
             })}
-          </>
-        );
-      };
+            </>
+          );
+        },
+        [data, algorithm, generateColor, squarify, labelConfig, hoveredNode, selectedNode]
+      );
 
       // Convert data to datasets format for BaseChart
-      const datasets = [
-        {
-          label: 'Treemap Data',
-          data: data,
-        },
-      ];
+      const datasets = useMemo(
+        () => [
+          {
+            label: 'Treemap Data',
+            data: data,
+          },
+        ],
+        [data]
+      );
 
       return (
         <BaseChart


### PR DESCRIPTION
This PR optimizes `TreemapChart` performance by preventing unnecessary re-renders of the child `BaseChart` component.

💡 **What:**
- Wrapped `renderContent` function in `useCallback`.
- Moved default prop values (`colorConfig`, `labelConfig`, `config`) to module-level constants.
- Wrapped `datasets` array creation in `useMemo`.

🎯 **Why:**
- `renderContent` was being recreated on every render of `TreemapChart`, causing `BaseChart` (which is memoized) to re-render unnecessarily because `renderContent` prop changed.
- Default prop values defined as inline objects (e.g., `config = {}`) were creating new references on every render, also breaking memoization.
- `datasets` array was created on every render, causing `BaseChart` to re-render.

📊 **Measured Improvement:**
- A reproduction test case confirmed that `renderContent` reference is now stable across re-renders when dependencies are unchanged.
- This prevents heavy re-computation in `ChartRenderer` (inside `BaseChart`) when `TreemapChart` re-renders due to unrelated prop changes or internal state updates (like tooltip position, although currently unused).


---
*PR created automatically by Jules for task [3166239470466062585](https://jules.google.com/task/3166239470466062585) started by @liimonx*