### PR TITLE
⚡ Optimize useChart real-time updates to avoid unnecessary re-renders

### DIFF
--- a/src/lib/composables/__tests__/useChart.test.tsx
+++ b/src/lib/composables/__tests__/useChart.test.tsx
@@ -1,0 +1,139 @@
+import { renderHook, act } from '@testing-library/react';
+import { useChartData } from '../useChart';
+import { ChartDataset } from '../../types/components';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('useChartData - Real-time Optimization', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not update processedData if data has not changed', () => {
+    const datasets: ChartDataset[] = [
+      {
+        label: 'Dataset 1',
+        data: [
+          { label: '1', value: 10 },
+          { label: '2', value: 20 },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useChartData(datasets, {
+        enableRealTime: true,
+        realTimeInterval: 1000,
+        enableDecimation: false,
+      })
+    );
+
+    const initialData = result.current.processedData;
+
+    // Advance time
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(result.current.processedData).toBe(initialData);
+  });
+
+  it('should update processedData if data length changes (mutation)', () => {
+    const datasets: ChartDataset[] = [
+      {
+        label: 'Dataset 1',
+        data: [
+          { label: '1', value: 10 },
+          { label: '2', value: 20 },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useChartData(datasets, {
+        enableRealTime: true,
+        realTimeInterval: 1000,
+        enableDecimation: false,
+      })
+    );
+
+    const initialData = result.current.processedData;
+
+    datasets[0].data.push({ label: '3', value: 30 });
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(result.current.processedData).not.toBe(initialData);
+    expect(result.current.processedData[0].data.length).toBe(3);
+  });
+
+  it('should update processedData if data value changes (mutation)', () => {
+    const datasets: ChartDataset[] = [
+      {
+        label: 'Dataset 1',
+        data: [
+          { label: '1', value: 10 },
+          { label: '2', value: 20 },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useChartData(datasets, {
+        enableRealTime: true,
+        realTimeInterval: 1000,
+        enableDecimation: false,
+      })
+    );
+
+    const initialData = result.current.processedData;
+
+    datasets[0].data[1].value = 25;
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(result.current.processedData).not.toBe(initialData);
+    expect(result.current.processedData[0].data[1].value).toBe(25);
+  });
+
+  it('should update processedData if historical data changes (mutation)', () => {
+    const datasets: ChartDataset[] = [
+      {
+        label: 'Dataset 1',
+        data: [
+          { label: '1', value: 10 },
+          { label: '2', value: 20 },
+          { label: '3', value: 30 },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useChartData(datasets, {
+        enableRealTime: true,
+        realTimeInterval: 1000,
+        enableDecimation: false,
+      })
+    );
+
+    const initialData = result.current.processedData;
+
+    // Mutate historical data (index 0)
+    datasets[0].data[0].value = 15;
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    // Should update
+    expect(result.current.processedData).not.toBe(initialData);
+    expect(result.current.processedData[0].data[0].value).toBe(15);
+  });
+});

--- a/src/lib/composables/useChart.ts
+++ b/src/lib/composables/useChart.ts
@@ -641,6 +641,23 @@ export function useChartData(
     realTimeInterval = 1000,
   } = options || {};
 
+  const lastDataSignature = useRef<string>('');
+
+  // Helper to generate a signature for the dataset to detect changes
+  const getDatasetSignature = useCallback((data: ChartDataset[]) => {
+    return data
+      .map(d => {
+        // Use JSON stringify for robustness to detect any value change, including historical data
+        return `${d.label}:${JSON.stringify(d.data)}`;
+      })
+      .join('|');
+  }, []);
+
+  // Update signature when processedData changes (e.g. via props)
+  useEffect(() => {
+    lastDataSignature.current = getDatasetSignature(processedData);
+  }, [processedData, getDatasetSignature]);
+
   // Data decimation for performance
   const decimateData = useCallback(
     (data: ChartDataset[], maxPoints: number) => {
@@ -711,11 +728,20 @@ export function useChartData(
     if (!enableRealTime) return undefined;
 
     const interval = setInterval(() => {
-      setProcessedData(prev => [...prev]); // Trigger re-render for real-time updates
+      setProcessedData(prev => {
+        const currentSignature = getDatasetSignature(prev);
+        // Only trigger update if signature changed
+        if (currentSignature === lastDataSignature.current) {
+          return prev;
+        }
+        // Note: We do not update lastDataSignature.current here to avoid side effects in updater.
+        // It will be updated by the useEffect([processedData]) when the state update completes.
+        return [...prev];
+      });
     }, realTimeInterval);
 
     return () => clearInterval(interval);
-  }, [enableRealTime, realTimeInterval]);
+  }, [enableRealTime, realTimeInterval, getDatasetSignature]);
 
   return {
     processedData,


### PR DESCRIPTION
Optimized `useChartData` to prevent forced re-renders in real-time mode when data is static.
Previously, `setInterval` would force a re-render every interval blindly.
Now, it checks a signature of the data (using `JSON.stringify`) and only updates state if the signature has changed.
This supports both immutable prop updates and mutable in-place data updates.

Verified with new unit tests ensuring correct behavior for various mutation scenarios.

---
*PR created automatically by Jules for task [11616647806669373191](https://jules.google.com/task/11616647806669373191) started by @liimonx*