### PR TITLE
🔒 Fix unsafe assignment of href attribute in VideoPlayer

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -146,10 +146,17 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
     const handleDownload = useCallback(() => {
       if (src) {
-        const a = document.createElement('a');
-        a.href = src;
-        a.download = 'video';
-        a.click();
+        try {
+          const url = new URL(src, window.location.origin);
+          if (['http:', 'https:', 'blob:', 'data:'].includes(url.protocol)) {
+            const a = document.createElement('a');
+            a.href = url.href;
+            a.download = 'video';
+            a.click();
+          }
+        } catch (e) {
+          // Ignore invalid URLs
+        }
       }
     }, [src]);
 


### PR DESCRIPTION
🎯 **What:** 
Fixed a security vulnerability in `VideoPlayer.tsx` where an unsafe assignment was made to an anchor tag's `href` attribute inside `handleDownload`.

⚠️ **Risk:** 
If the `src` prop were user-controlled or sourced from an untrusted origin, a malicious URL (such as `javascript:alert('XSS')`) could be assigned to the `href` attribute. When a user clicks the download button, this payload would execute in the context of the application, leading to Cross-Site Scripting (XSS).

🛡️ **Solution:** 
Replaced direct string assignment with a URL constructor that parses the `src`. Validates the resulting `url.protocol` against a strict allowlist (`['http:', 'https:', 'blob:', 'data:']`). Invalid URLs or unsafe protocols are ignored via a try-catch block, safely neutralizing the vulnerability while maintaining robust support for standard web protocols and relative paths.

---
*PR created automatically by Jules for task [15183303262097386734](https://jules.google.com/task/15183303262097386734) started by @liimonx*