### PR TITLE
🧹 [Code Health] Remove unused jsPDF code from useChartExport

### DIFF
--- a/src/lib/composables/useChartExport.ts
+++ b/src/lib/composables/useChartExport.ts
@@ -139,20 +139,10 @@ export function useChartExport() {
 
   // Export as PDF
   const exportAsPDF = useCallback(
-    async (svgElement: SVGSVGElement, options: ExportOptions): Promise<void> => {
-      // Note: This requires a PDF library like jsPDF
-      // For now, we'll convert to canvas and then to PDF
-      const canvas = await svgToCanvas(svgElement, options);
-
-      // This would require jsPDF library
-      // const pdf = new jsPDF();
-      // const imgData = canvas.toDataURL('image/png');
-      // pdf.addImage(imgData, 'PNG', 0, 0);
-      // pdf.save(options.filename || 'chart.pdf');
-
-      console.warn('PDF export requires jsPDF library to be installed');
+    async (_svgElement: SVGSVGElement, _options: ExportOptions): Promise<void> => {
+      console.warn('PDF export requires a PDF library to be installed');
     },
-    [svgToCanvas]
+    []
   );
 
   // Export data as CSV


### PR DESCRIPTION
🎯 **What:** Removed commented out jsPDF code and the preceding unused `svgToCanvas` conversion step within the `exportAsPDF` function in `src/lib/composables/useChartExport.ts`. Updated the unused arguments with underscores (`_svgElement`, `_options`) to satisfy linting.
💡 **Why:** Removing dead code and unused variable assignments improves readability and prevents confusion. The code simply warned the user that a PDF library is required, so executing `svgToCanvas` needlessly wasted processing time before issuing the warning.
✅ **Verification:** Verified by running `npm run typecheck`, `npm run lint` on the file, and running `bun run vitest run src/lib/composables` to ensure no related tests failed due to this change. Code review was requested and passed.
✨ **Result:** Improved maintainability, cleaner codebase, and minor performance gain for the unimplemented PDF export function.

---
*PR created automatically by Jules for task [5662485494497717858](https://jules.google.com/task/5662485494497717858) started by @liimonx*