### PR TITLE
🧹 Code Health: Remove deprecated onOpen/onClose handlers in Accordion type

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -22,8 +22,6 @@ const IS_DISABLED_CLASS = ACCORDION.CLASSES.IS_DISABLED;
 
 const mockHandlers = {
   onOpenChange: fn(() => {}),
-  onOpen: fn(() => {}),
-  onClose: fn(() => {}),
 };
 
 // Sample content for stories
@@ -222,20 +220,6 @@ const meta = {
         type: { summary: '(open: boolean) => void' },
       },
     },
-    onOpen: {
-      action: 'onOpen',
-      description: 'Callback when accordion opens',
-      table: {
-        type: { summary: '() => void' },
-      },
-    },
-    onClose: {
-      action: 'onClose',
-      description: 'Callback when accordion closes',
-      table: {
-        type: { summary: '() => void' },
-      },
-    },
   },
 } satisfies Meta<typeof Accordion>;
 
@@ -268,8 +252,6 @@ export const WithAllProps: Story = {
     iconPosition: 'left',
     disabled: false,
     onOpenChange: mockHandlers.onOpenChange,
-    onOpen: mockHandlers.onOpen,
-    onClose: mockHandlers.onClose,
   },
   parameters: {
     docs: {

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -28,23 +28,6 @@ describe('Accordion Component', () => {
     expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('calls legacy onOpen/onClose handlers', () => {
-    const onOpen = vi.fn();
-    const onClose = vi.fn();
-    render(
-      <Accordion title="Test" onOpen={onOpen} onClose={onClose}>
-        Content
-      </Accordion>
-    );
-    const button = screen.getByRole('button');
-
-    fireEvent.click(button);
-    expect(onOpen).toHaveBeenCalled();
-
-    fireEvent.click(button);
-    expect(onClose).toHaveBeenCalled();
-  });
-
   it('handles controlled state', () => {
     const onOpenChange = vi.fn();
     const { rerender } = render(

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -114,8 +114,6 @@ const AccordionImpl = memo(
     defaultOpen = false,
     isOpen: controlledOpen,
     onOpenChange,
-    onOpen,
-    onClose,
     disabled = false,
     iconPosition = 'right',
     icon,
@@ -143,8 +141,6 @@ const AccordionImpl = memo(
       iconPosition,
       isOpen: controlledOpen,
       onOpenChange,
-      onOpen,
-      onClose,
     });
 
     const headerClassNames = generateHeaderClassNames();

--- a/src/lib/composables/useAccordion.ts
+++ b/src/lib/composables/useAccordion.ts
@@ -66,13 +66,6 @@ export function useAccordion(
       }
 
       defaultProps.onOpenChange?.(nextOpen);
-
-      // Call legacy handlers
-      if (nextOpen) {
-        defaultProps.onOpen?.();
-      } else {
-        defaultProps.onClose?.();
-      }
     }
   };
 

--- a/src/lib/types/components.ts
+++ b/src/lib/types/components.ts
@@ -813,17 +813,6 @@ export interface AccordionProps extends BaseComponentProps {
   onOpenChange?: (open: boolean) => void;
 
   /**
-   * @deprecated Use onOpenChange instead
-   * Optional open handler
-   */
-  onOpen?: () => void;
-
-  /**
-   * @deprecated Use onOpenChange instead
-   * Optional close handler
-   */
-  onClose?: () => void;
-  /**
    * Glass morphism effect for the accordion
    * Can be a boolean to enable with default settings, or an object with AtomixGlassProps to customize the effect
    */


### PR DESCRIPTION
🎯 **What:** The deprecated `onOpen` and `onClose` props have been completely removed from the `Accordion` component's API, including its type definition, the `useAccordion` hook, the internal implementation, its test suite, and its Storybook stories.

💡 **Why:** This improves maintainability and readability by consolidating state change handling into a single, standard `onOpenChange` callback, removing legacy redundancy.

✅ **Verification:**
1. Ran `bun x vitest run src/components/Accordion` to ensure all tests continue to pass.
2. Started Storybook and verified the `Accordion` visual UI state (both closed and open via click events) correctly utilizing a Playwright script.

✨ **Result:** A cleaner component API that drops dead legacy callbacks.

---
*PR created automatically by Jules for task [8366264755316458596](https://jules.google.com/task/8366264755316458596) started by @liimonx*