### PR TITLE
Fix Button rendering when disabled and href is provided

### DIFF
--- a/src/components/Button/Button.stories.disabled-link.tsx
+++ b/src/components/Button/Button.stories.disabled-link.tsx
@@ -1,0 +1,10 @@
+import { Button } from './Button';
+
+export const DisabledLinkExample = {
+  render: () => (
+    <div style={{ padding: '20px', display: 'flex', gap: '10px' }}>
+      <Button href="/home" disabled>Disabled Link Button</Button>
+      <Button href="/home">Normal Link Button</Button>
+    </div>
+  ),
+};

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -406,6 +406,16 @@ export const DisabledState: Story = {
   },
 };
 
+export const DisabledLinkState: Story = {
+  args: {
+    label: 'Disabled Link Button',
+    variant: 'primary',
+    size: 'md',
+    disabled: true,
+    href: '/home',
+  },
+};
+
 /**
  * Shows button in active state
  */

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -75,22 +75,27 @@ describe('Button Component', () => {
   });
 
   it('renders as disabled link when disabled and href provided', () => {
-    // Current implementation might be buggy here, let's see
     render(
       <Button href="/home" disabled>
         Home
       </Button>
     );
-    const link = screen.queryByRole('link');
-    const button = screen.queryByRole('button');
 
-    // If it renders as button when disabled (which logic suggested), then:
-    if (button) {
-      expect(button).toBeDisabled();
-    } else if (link) {
-      expect(link).toHaveAttribute('aria-disabled', 'true');
-      // Should not navigate
-    }
+    // An anchor tag without an href attribute is not considered a 'link' role.
+    // It's considered a generic text element, but in our component it has role='link' implicitly? No.
+    // Actually, an anchor without href is generic. But it might have button styles.
+    // Let's get it by text and assert it's an anchor without href.
+    const element = screen.getByText('Home').closest('a');
+    expect(element).toBeInTheDocument();
+
+    // It shouldn't have an href attribute because it's disabled.
+    expect(element).not.toHaveAttribute('href');
+
+    // It should have aria-disabled true
+    expect(element).toHaveAttribute('aria-disabled', 'true');
+
+    // It should have disabled class
+    expect(element).toHaveClass('c-btn--disabled');
   });
 
   it('forwards ref', () => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -62,7 +62,7 @@ export const Button = React.memo(
       // If disabled, we still check href, but we might want to render as button or anchor with aria-disabled
       // The previous logic was Boolean(href && !isDisabled). This meant if disabled, it renders as <button>.
       // This is a safe fallback for disabled links.
-      const shouldRenderAsLink = Boolean(href && !isDisabled);
+      const shouldRenderAsLink = Boolean(href);
 
       // Resolve icon element - support both icon (ReactNode) and iconName (string)
       const iconElement = iconName ? (
@@ -226,8 +226,8 @@ export const Button = React.memo(
           const linkProps = {
             ...buttonProps,
             ref: ref as any, // linkComponent usually forwards ref to anchor
-            href,
-            to: href,
+            href: isDisabled ? undefined : href,
+            to: isDisabled ? undefined : href,
             target,
             rel: target === '_blank' ? 'noopener noreferrer' : undefined,
           };
@@ -239,7 +239,7 @@ export const Button = React.memo(
             <a
               {...buttonProps}
               ref={ref as React.Ref<HTMLAnchorElement>}
-              href={href}
+              href={isDisabled ? undefined : href}
               target={target}
               rel={target === '_blank' ? 'noopener noreferrer' : undefined}
             >


### PR DESCRIPTION
Fix a bug where disabled buttons with an `href` prop rendered incorrectly.

---
*PR created automatically by Jules for task [14086028120648500122](https://jules.google.com/task/14086028120648500122) started by @liimonx*