### PR TITLE
style: replace uppercase RGBA with lowercase rgba

### DIFF
--- a/src/styles/99-utilities/_utilities.link.scss
+++ b/src/styles/99-utilities/_utilities.link.scss
@@ -64,12 +64,11 @@ $utilities-link: (
 $enable-important-utilities: true !default;
 $link-shade-percentage: 15% !default;
 
-// All-caps `RGBA()` function used because of this Sass bug: https://github.com/sass/node-sass/issues/2251
 @each $color, $value in color-maps.$theme-colors {
   .u-link-#{$color} {
-    color: RGBA(var(--#{config.$prefix}#{$color}-rgb), var(--#{config.$prefix}u-link-opacity, 1))
+    color: rgba(var(--#{config.$prefix}#{$color}-rgb), var(--#{config.$prefix}u-link-opacity, 1))
       if($enable-important-utilities, !important, null);
-    text-decoration-color: RGBA(
+    text-decoration-color: rgba(
         var(--#{config.$prefix}#{$color}-rgb),
         var(--#{config.$prefix}u-link-underline-opacity, 1)
       )
@@ -83,9 +82,9 @@ $link-shade-percentage: 15% !default;
           shade-color($value, $link-shade-percentage),
           tint-color($value, $link-shade-percentage)
         );
-        color: RGBA(#{to-rgb($hover-color)}, var(--#{config.$prefix}u-link-opacity, 1))
+        color: rgba(#{to-rgb($hover-color)}, var(--#{config.$prefix}u-link-opacity, 1))
           if($enable-important-utilities, !important, null);
-        text-decoration-color: RGBA(
+        text-decoration-color: rgba(
             #{to-rgb($hover-color)},
             var(--#{config.$prefix}u-link-underline-opacity, 1)
           )


### PR DESCRIPTION
Removed the obsolete `RGBA()` uppercase workaround in `src/styles/99-utilities/_utilities.link.scss` that was initially meant to circumvent an old `node-sass` case-sensitivity bug. Since the project uses Dart Sass (`sass` ^1.69.0), lowercase `rgba()` parses fine with custom CSS properties. Cleaned up the associated comment. Confirmed the fix does not break SCSS compilation by running `npm run build:styles`.

---
*PR created automatically by Jules for task [16403606839567270539](https://jules.google.com/task/16403606839567270539) started by @liimonx*